### PR TITLE
fix: Chat history template name is accepting empty strings as well

### DIFF
--- a/app.py
+++ b/app.py
@@ -682,7 +682,7 @@ async def rename_conversation():
 
     ## update the title
     title = request_json.get("title", None)
-    if not title:
+    if not title or title.strip() == "":
         return jsonify({"error": "title is required"}), 400
     conversation["title"] = title
     updated_conversation = await cosmos_conversation_client.upsert_conversation(

--- a/frontend/src/components/ChatHistory/ChatHistoryListItem.tsx
+++ b/frontend/src/components/ChatHistory/ChatHistoryListItem.tsx
@@ -25,6 +25,7 @@ import { AppStateContext } from '../../state/AppProvider'
 import { GroupedChatHistory } from './ChatHistoryList'
 
 import styles from './ChatHistoryPanel.module.css'
+import _ from 'lodash'
 
 interface ChatHistoryListItemCellProps {
   item?: Conversation
@@ -123,6 +124,17 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
   const handleSaveEdit = async (e: any) => {
     e.preventDefault()
     if (errorRename || renameLoading) {
+      return
+    }
+    if (_.trim(editTitle) === "") {
+      setErrorRename('Error: Title is required.')
+      setTimeout(() => {
+        setErrorRename(undefined)
+        setTextFieldFocused(true)
+        if (textFieldRef.current) {
+          textFieldRef.current.focus()
+        }
+      }, 5000)
       return
     }
     if (editTitle == item.title) {


### PR DESCRIPTION
**Issue Description:**

The chat history template name field is currently accepting empty strings, which is causing issues with data integrity and user experience.

**Purpose:**

The template name should not accept empty strings to:

- Ensure that users provide meaningful and descriptive names for their chat history templates.
- Prevent the creation of templates with no name, which could lead to confusion or incorrect UI behavior.
- Maintain data integrity across the application by ensuring all templates have unique and valid identifiers.

**Problem It Solves:**

1.	**Prevents Invalid Data**: By disallowing empty strings, we ensure that only valid template names are saved and processed.
2.	**Improves User Experience**: Users will be prompted to enter a valid name, ensuring a smoother interaction with the application.
3.	**Avoids UI Issues**: Empty template names may cause bugs in UI rendering or lead to broken links or placeholders.

**Proposed Solution:**
•	Add validation to the template name field to ensure it is not an empty string.
•	Provide appropriate error messaging if the user attempts to submit an empty name.

**Before Fix:** (Allowing white spaces)

<img width="322" alt="image" src="https://github.com/user-attachments/assets/62881e61-f663-41bc-b7e6-4f8f3860d503">

**After Fix:**

<img width="227" alt="image" src="https://github.com/user-attachments/assets/ebc4a5ab-5aad-4b49-a052-396eb67b2978">


