### PR TITLE
'fix' Edit and Delete btn disable when message is generating, After generating the response in Generate section restricting user to move to another sections.

### DIFF
--- a/frontend/src/components/ChatHistory/ChatHistoryListItem.tsx
+++ b/frontend/src/components/ChatHistory/ChatHistoryListItem.tsx
@@ -60,7 +60,8 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
   const [errorRename, setErrorRename] = useState<string | undefined>(undefined)
   const [textFieldFocused, setTextFieldFocused] = useState(false)
   const textFieldRef = useRef<ITextField | null>(null)
-
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(false);
+  
   const appStateContext = React.useContext(AppStateContext)
   const isSelected = item?.id === appStateContext?.state.currentChat?.id
   const dialogContentProps = {
@@ -94,6 +95,12 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
       setEditTitle('')
     }
   }, [appStateContext?.state.currentChat?.id, item?.id])
+
+  useEffect(()=>{
+    let v = appStateContext?.state.isRequestInitiated;
+    if(v!=undefined)
+      setIsButtonDisabled(v && isSelected)
+  },[appStateContext?.state.isRequestInitiated])
 
   const onDelete = async () => {
     const response = await historyDelete(item.id)
@@ -267,6 +274,7 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
                   iconProps={{ iconName: 'Delete' }}
                   title="Delete"
                   onClick={toggleDeleteDialog}
+                  disabled={isButtonDisabled}
                   onKeyDown={e => (e.key === ' ' ? toggleDeleteDialog() : null)}
                 />
                 <IconButton
@@ -274,6 +282,7 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
                   iconProps={{ iconName: 'Edit' }}
                   title="Edit"
                   onClick={onEdit}
+                  disabled={isButtonDisabled}
                   onKeyDown={e => (e.key === ' ' ? onEdit() : null)}
                 />
               </Stack>

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -85,6 +85,14 @@ const Sidebar = (): JSX.Element => {
   const navigate = useNavigate()
   const location = useLocation()
   const [name, setName] = useState<string>('')
+  useEffect(() => {
+  if(appStateContext?.state.isRequestInitiated == true){
+    NavigationButtonStates.Disabled
+  }
+  else{
+    NavigationButtonStates.Active
+  }
+})
 
   useEffect(() => {
     if (!appStateContext) {
@@ -113,7 +121,12 @@ const Sidebar = (): JSX.Element => {
   }
 
   const currentView = determineView()
-  const isGenerating = appStateContext?.state.isGenerating
+    // inactive, disabled, active
+    var draftButtonState = NavigationButtonStates.Disabled
+    if (appStateContext?.state.draftedDocument) {
+      draftButtonState = currentView === 'draft' ? NavigationButtonStates.Active : NavigationButtonStates.Inactive
+    }
+  const isGenerating = appStateContext?.state.isRequestInitiated
 
   return (
     <Stack className={styles.sidebarContainer}>
@@ -125,9 +138,9 @@ const Sidebar = (): JSX.Element => {
           text={'Browse'}
           buttonState={
             currentView === 'chat'
-              ? NavigationButtonStates.Active
-              : appStateContext?.state.isGenerating
-                ? NavigationButtonStates.Disabled
+            ? NavigationButtonStates.Active
+            : appStateContext?.state.isRequestInitiated
+              ? NavigationButtonStates.Disabled
                 : NavigationButtonStates.Inactive
           }
           onClick={() => {
@@ -141,9 +154,10 @@ const Sidebar = (): JSX.Element => {
           buttonState={
             currentView === 'generate'
               ? NavigationButtonStates.Active
-              : appStateContext?.state.isGenerating
+              : appStateContext?.state.isRequestInitiated
                 ? NavigationButtonStates.Disabled
                 : NavigationButtonStates.Inactive
+
           }
           onClick={() => {
             if (!isGenerating) {
@@ -153,17 +167,10 @@ const Sidebar = (): JSX.Element => {
         />
         <NavigationButton
           text={'Draft'}
-          buttonState={
-            currentView === 'draft'
-              ? NavigationButtonStates.Active
-              : appStateContext?.state.isGenerating
-                ? NavigationButtonStates.Disabled
-                : NavigationButtonStates.Inactive
-          }
+          buttonState={draftButtonState}
+         
           onClick={() => {
-            if (!isGenerating) {
-              navigate('/draft')
-            }
+            navigate('/draft')
           }}
         />
       </Stack>

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -287,6 +287,7 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
     setShowLoadingMessage(true)
     const abortController = new AbortController()
     abortFuncs.current.unshift(abortController)
+    appStateContext?.dispatch({ type: 'SET_IS_REQUEST_INITIATED', payload: true })
 
     const userMessage: ChatMessage = {
       id: uuid(),
@@ -402,6 +403,7 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
       setShowLoadingMessage(false)
       appStateContext?.dispatch({ type: 'GENERATE_ISLODING', payload: false })
       abortFuncs.current = abortFuncs.current.filter(a => a !== abortController)
+      appStateContext?.dispatch({ type: 'SET_IS_REQUEST_INITIATED', payload: false })
       setProcessMessages(messageStatus.Done)
     }
 
@@ -414,6 +416,8 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
     setShowLoadingMessage(true)
     const abortController = new AbortController()
     abortFuncs.current.unshift(abortController)
+    appStateContext?.dispatch({ type: 'SET_IS_REQUEST_INITIATED', payload: true })
+
 
     const userMessage: ChatMessage = {
       id: uuid(),
@@ -640,6 +644,7 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
       setShowLoadingMessage(false)
       abortFuncs.current = abortFuncs.current.filter(a => a !== abortController)
       setProcessMessages(messageStatus.Done)
+      appStateContext?.dispatch({ type: 'SET_IS_REQUEST_INITIATED', payload: false })
     }
     return abortController.abort()
   }

--- a/frontend/src/state/AppProvider.tsx
+++ b/frontend/src/state/AppProvider.tsx
@@ -30,6 +30,7 @@ export interface AppState {
   draftedDocument: DraftedDocument | null
   draftedDocumentTitle: string
   isGenerating: boolean
+  isRequestInitiated : boolean
 }
 
 export type Action =
@@ -56,6 +57,7 @@ export type Action =
   | { type: 'UPDATE_GENERATE_CHAT'; payload: Conversation | null }
   | { type: 'UPDATE_DRAFTED_DOCUMENT_TITLE'; payload: string }
   | { type: 'GENERATE_ISLODING'; payload: boolean }
+  | { type: 'SET_IS_REQUEST_INITIATED'; payload: boolean }
 
 const initialState: AppState = {
   isChatHistoryOpen: false,
@@ -73,7 +75,8 @@ const initialState: AppState = {
   feedbackState: {},
   draftedDocument: null,
   draftedDocumentTitle: '',
-  isGenerating: false
+  isGenerating: false,
+  isRequestInitiated: false,
 }
 
 export const AppStateContext = createContext<

--- a/frontend/src/state/AppReducer.tsx
+++ b/frontend/src/state/AppReducer.tsx
@@ -103,6 +103,8 @@ export const appStateReducer = (state: AppState, action: Action): AppState => {
       return { ...state, draftedDocumentTitle: action.payload }
     case 'GENERATE_ISLODING':
       return { ...state, isGenerating: action.payload }
+      case 'SET_IS_REQUEST_INITIATED' : 
+      return {...state, isRequestInitiated : action.payload}
     default:
       return state
   }


### PR DESCRIPTION
### Motivation and Context

**Bug10177**
Before:
![image](https://github.com/user-attachments/assets/d2ecb3c0-5b7a-4c23-8f55-c34f037c6842)

After:
![image](https://github.com/user-attachments/assets/61584471-64d7-4c3e-afbf-053f4044f07c)

**Bug 9825** 
Before:
![image](https://github.com/user-attachments/assets/8f47b950-ffee-4e02-967e-78e52233abdd)


After:
<img width="765" alt="image (9)" src="https://github.com/user-attachments/assets/932bba17-a012-459a-a263-4e938733567f">

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
